### PR TITLE
Vedtægtsforslag: Offentliggørelse af mødereferater

### DIFF
--- a/fklub-vedtaegter.tex
+++ b/fklub-vedtaegter.tex
@@ -142,7 +142,7 @@ være bestyrelsen i hænde senest en uge før mødet finder
 
 \item Bestyrelsen skal som udgangspunkt føre referat ved møder.
   Referater skal gøres tilgængelig for F-Klubbens medlemmer.
-  Referater kan indeholde lukkede punkter, hvis indhold ikke offentliggøres.
+  Referater kan indeholde lukkede punkter, hvis indhold ikke skal offentliggøres.
 
 \item F-orældrerådet består af et antal
   personer der har været medlem af F-klubben i mindst tre år.

--- a/fklub-vedtaegter.tex
+++ b/fklub-vedtaegter.tex
@@ -140,6 +140,9 @@ være bestyrelsen i hænde senest en uge før mødet finder
   være ansvarlig for faglige arrangementer, og at holde styr med
   F-klubbens IT- og papirsvirke.
 
+\item Bestyrelsen skal som udgangspunkt føre referat ved møder.
+  Referater skal gøres tilgængelig for F-Klubbens medlemmer.
+  Referater kan indeholde lukkede punkter, hvis indhold ikke offentliggøres.
 
 \item F-orældrerådet består af et antal
   personer der har været medlem af F-klubben i mindst tre år.


### PR DESCRIPTION
For at gøre forstyrrelsen mere transparent, bør referater offentliggøres for medlemmer

#OpenSource