### PR TITLE
Fix spelling errors

### DIFF
--- a/fklub-vedtaegter.tex
+++ b/fklub-vedtaegter.tex
@@ -17,7 +17,7 @@
 
 \begin{list}
 {\S \arabic{fpara}}{\usecounter{fpara}}
-\section{Formål og medlemsskab}
+\section{Formål og medlemskab}
 \item Foreningens navn er F-klubben. Foreningens hjemsted er Aalborg
   kommune. Foreningens regnskabsår er fra 1.7.\ til 30.6.
   
@@ -53,8 +53,8 @@
 \item \label{par-gen} F-klubbens ordinære generalforsamling
   søges afholdt hvert år i september måned. Indkaldelse sker med 14
   dages varsel ved udsendelse af elektronisk post til alle aktive
-  medlemmer. Bestyrelsen kan i tilfælde af force maheure udsætte 
-  generalforsamlingen. Generalforsamligen skal i så fald indkalses 
+  medlemmer. Bestyrelsen kan i tilfælde af force majeure udsætte 
+  generalforsamlingen. Generalforsamlingen skal i så fald indkaldes 
   snarest efter det igen er muligt. Indkaldelsen skal indeholde et forslag til
   dagsorden, udarbejdet af bestyrelsen. Dagsorden ved en ordinær
   generalforsamling bør indeholde følgende punkter, og som minimum
@@ -89,10 +89,10 @@ være bestyrelsen i hænde senest en uge før mødet finder
 \item Ekstraordinær generalforsamling kan indkaldes, når
   bestyrelsen finder det påkrævet, eller når mindst 20 medlemmer 
   forlanger det. I sidstnævnte tilfælde skal generalforsamlingen afholdes 
-	senest fire uger efter, at forespørgslen er kommet bestyrtelsen i
+	senest fire uger efter, at forespørgslen er kommet bestyrelsen i
 	hænde.
   En ekstraordinær generalforsamling indkaldes efter samme regler som i \S
-  \ref{par-gen}. Dog er det ikke muligt for bestyrrelsen af udsætte en ekstraordinær
+  \ref{par-gen}. Dog er det ikke muligt for bestyrelsen at udsætte en ekstraordinær
   generalforsamling. Dagsordenen fastsættes af bestyrelsen, dog kan et flertal 
   af de fremmødte kræve valg til bestyrelsen. 
   
@@ -138,7 +138,7 @@ være bestyrelsen i hænde senest en uge før mødet finder
 \item Bestyrelsen fordeler selv sine arbejdsopgaver, der som minimum
   består af at holde kontakt med de autonome F-klub-udvalg, at
   være ansvarlig for faglige arrangementer, og at holde styr med
-  F-klubbens IT- og papirsvirke.
+  F-klubbens IT- og papir virke.
 
 
 \item F-orældrerådet består af et antal


### PR DESCRIPTION
This might be a bit controversial, since we like to keep things as is in our community. However I feel when this is document is what we legally follow, that it is a good idea to fix these things.
I am uncertain what 'papirsvirke' should be, since the only thing that google shows when googling the word is our 'vedtægter'. I think I corrected it properly.